### PR TITLE
Enable running `menu` from arbitrary folder

### DIFF
--- a/menu
+++ b/menu
@@ -13,15 +13,8 @@
 version=0.224
 
 
-if [ ! -e menu ]
-then
-  echo
-  echo "Ensure you run this file from the SAME folder as where it was"
-  echo "installed, otherwise the kitchen will have problems running the"
-  echo "scripts.  After you 'cd' to the correct folder, start the kitchen"
-  echo "with the ./menu command, NOT with any other command or method!"
-  exit 0
-fi
+# cd to the directory of this script
+cd "$(dirname "$0")
 
 dir_list=( original_update scripts tools )
 error_found=0


### PR DESCRIPTION
Instead of asking the user to change directory, let the script do it by itself.

`$0` expands to the filename of the script, then `dirname` extracts its
containing directory. `cd` changes the _current directory_ to it. Then,
everything else works as before.
